### PR TITLE
remove filter-icon broad styling - make more targeted

### DIFF
--- a/app/addons/documents/assets/scss/changes.scss
+++ b/app/addons/documents/assets/scss/changes.scss
@@ -65,14 +65,6 @@
     }
   }
 
-  // .fonticon-filter {
-  //   position: absolute;
-  //   left: -25px;
-  //   top: 10px;
-  //   color: $cf-text-fonticon01;
-  //   font-size: 20px;
-  // }
-
   form {
     margin: 0;
   }

--- a/app/addons/documents/assets/scss/changes.scss
+++ b/app/addons/documents/assets/scss/changes.scss
@@ -64,13 +64,15 @@
       }
     }
   }
-  .fonticon-filter {
-    position: absolute;
-    left: -25px;
-    top: 10px;
-    color: $cf-text-fonticon01;
-    font-size: 20px;
-  }
+
+  // .fonticon-filter {
+  //   position: absolute;
+  //   left: -25px;
+  //   top: 10px;
+  //   color: $cf-text-fonticon01;
+  //   font-size: 20px;
+  // }
+
   form {
     margin: 0;
   }
@@ -165,7 +167,6 @@
 @keyframes highlight-element {
   from {
     background-color: $cf-border-color01;
-    
   }
   to {
     background-color: $cf-background01;

--- a/app/addons/documents/assets/scss/index-results.scss
+++ b/app/addons/documents/assets/scss/index-results.scss
@@ -203,14 +203,6 @@ a.document-result-screen__toolbar-create-btn:visited {
     overflow: visible;
   }
 
-  // .fonticon-filter {
-  //   position: absolute;
-  //   right: 6px;
-  //   top: 6px;
-  //   pointer-events: none;
-  //   color: $cf-text-fonticon01;
-  // }
-
   .table-container-autocomplete {
     position: relative;
     width: 128px;

--- a/app/addons/documents/assets/scss/index-results.scss
+++ b/app/addons/documents/assets/scss/index-results.scss
@@ -117,7 +117,6 @@ a.document-result-screen__toolbar-create-btn:visited {
 }
 
 .table-view-docs {
-
   .bulk-action-component {
     padding-bottom: 0;
     min-height: 0;
@@ -204,13 +203,13 @@ a.document-result-screen__toolbar-create-btn:visited {
     overflow: visible;
   }
 
-  .fonticon-filter {
-    position: absolute;
-    right: 6px;
-    top: 6px;
-    pointer-events: none;
-    color: $cf-text-fonticon01;
-  }
+  // .fonticon-filter {
+  //   position: absolute;
+  //   right: 6px;
+  //   top: 6px;
+  //   pointer-events: none;
+  //   color: $cf-text-fonticon01;
+  // }
 
   .table-container-autocomplete {
     position: relative;

--- a/app/addons/documents/assets/scss/partition-key.scss
+++ b/app/addons/documents/assets/scss/partition-key.scss
@@ -24,12 +24,16 @@
   border: none;
   color: $cf-text-fonticon01;
   font-size: 1rem;
-  .fonticon-filter {
-    font-size: 1.25rem;
-    padding-right: 6px;
-  }
+  // .fonticon-filter {
+  //   font-size: 1.25rem;
+  //   padding-right: 6px;
+  // }
   &:hover {
     color: $cf-brand-hightlight-hover;
+  }
+
+  i {
+    margin-right: 10px;
   }
 }
 

--- a/app/addons/documents/assets/scss/partition-key.scss
+++ b/app/addons/documents/assets/scss/partition-key.scss
@@ -24,10 +24,7 @@
   border: none;
   color: $cf-text-fonticon01;
   font-size: 1rem;
-  // .fonticon-filter {
-  //   font-size: 1.25rem;
-  //   padding-right: 6px;
-  // }
+
   &:hover {
     color: $cf-brand-hightlight-hover;
   }

--- a/app/addons/documents/partition-key/PartitionKeySelector.js
+++ b/app/addons/documents/partition-key/PartitionKeySelector.js
@@ -77,8 +77,7 @@ export default class PartitionKeySelector extends React.Component {
   globalHeader() {
     return (
       <button onClick={this.onModeSwitchClick} title="Partition Key Selector" className="button partition-selector__switch">
-        <i className="fonticon-filter"></i>
-        No partition selected
+        <i className="fonticon-filter"></i><span>No partition selected</span>
       </button>
     );
   }
@@ -99,6 +98,7 @@ export default class PartitionKeySelector extends React.Component {
       partName = this.props.partitionKey;
       className += ' partition-selector__key--active';
     }
+
     return (
       <React.Fragment>
         <button onClick={this.onModeSwitchClick} title="Partition Key Selector" className="button partition-selector__switch button partition-selector__switch--active">


### PR DESCRIPTION
- remove filter-icon broad styling - make more targeted
   - current implementation is interfering with changes to Changes.

### Post-changes
<img width="526" alt="Screenshot 2023-02-23 at 16 18 53" src="https://user-images.githubusercontent.com/94444185/220967140-6581c7f0-9892-4224-b1de-ca09755bb75c.png">
<img width="509" alt="Screenshot 2023-02-23 at 16 19 03" src="https://user-images.githubusercontent.com/94444185/220967145-80c06fdf-caae-4958-9581-8965657f7591.png">
<img width="498" alt="Screenshot 2023-02-23 at 16 19 12" src="https://user-images.githubusercontent.com/94444185/220967148-dc046990-9c5b-49e7-9b7f-1288bdaf0c6b.png">
