### PR TITLE
update clipboard icon to use fonticon rather than fa

### DIFF
--- a/app/addons/components/components/copy.js
+++ b/app/addons/components/components/copy.js
@@ -48,7 +48,7 @@ export class Copy extends React.Component {
 
   getClipboardElement () {
     if (this.props.displayType === 'icon') {
-      return (<i aria-hidden="true" className="fontawesome icon-paste"></i>);
+      return (<i aria-hidden="true" className="fonticon-clipboard"></i>);
     }
     return this.props.textDisplay;
   }


### PR DESCRIPTION
Switch to fonticon clipboard icon from fa


![Screenshot 2023-02-24 at 13 18 07](https://user-images.githubusercontent.com/94444185/221188453-546156fe-4c7a-4afd-9905-6568455c6701.png)
![Screenshot 2023-02-24 at 13 18 31](https://user-images.githubusercontent.com/94444185/221188458-0455729b-ac0e-4178-88dd-a76a6eb3ace8.png)
