### PR TITLE
Restrict input text email password width on desktop

### DIFF
--- a/app/addons/permissions/assets/scss/permissions.scss
+++ b/app/addons/permissions/assets/scss/permissions.scss
@@ -38,3 +38,10 @@
 #dashboard #dashboard-content div.permissions-page {
   padding: 5px $cf-main-content-padding;
 }
+
+/* Bootstrap 'lg' breakpoint */
+@media (min-width: 992px) {
+  .permission-items.list-unstyled {
+    width: calc($desktop-input-width + 110px);
+  }
+}

--- a/app/addons/permissions/assets/scss/permissions.scss
+++ b/app/addons/permissions/assets/scss/permissions.scss
@@ -42,6 +42,7 @@
 /* Bootstrap 'lg' breakpoint */
 @media (min-width: 992px) {
   .permission-items.list-unstyled {
-    width: calc($desktop-input-width + 110px);
+    width: 100%;
+    max-width: calc($desktop-input-width + 110px);
   }
 }

--- a/assets/scss/_variables.scss
+++ b/assets/scss/_variables.scss
@@ -211,6 +211,9 @@ $input-btn-focus-color: rgba($cf-brand-highlight, .25);
 $input-focus-border-color: tint-color($cf-brand-highlight, 50%);
 $input-bg: $cf-input-bg;
 
+// inputs
+$desktop-input-width: 250px;
+
 // modals
 $modal-backdrop-opacity: 0.5;
 

--- a/assets/scss/fauxton.scss
+++ b/assets/scss/fauxton.scss
@@ -710,3 +710,23 @@ body .control-toggle-include-docs span {
   margin: 100px;
   box-shadow: 2px 2px 5px $cf-border-color02;
 }
+
+/* prevent button (etc) on input group wrapping under text input */
+.input-group {
+  flex-wrap: nowrap !important;
+  button {
+    white-space: nowrap;
+  }
+}
+
+/* Bootstrap 'lg' breakpoint */
+@media (min-width: 992px) {
+  input[type='text'], input[type='email'], input[type='password'] {
+    /* for flex elements */
+    flex-grow: 0 !important;
+    flex-basis: $desktop-input-width !important;
+    /* for block elements */
+    width:100%;
+    max-width: $desktop-input-width;
+  }
+}


### PR DESCRIPTION
Restrict input text, email, and password width on desktop, as well as list items on the Permissions page

![Screenshot 2023-02-24 at 13 21 22](https://user-images.githubusercontent.com/94444185/221188940-bab280a7-e5bf-4d73-bebf-a497d9e28d95.png)
![Screenshot 2023-02-24 at 13 21 31](https://user-images.githubusercontent.com/94444185/221188942-8b0c2217-57a2-407a-8ada-d49b6cb95bc3.png)
