### PR TITLE
fix dropdown of the View Attachments button

### DIFF
--- a/app/addons/documents/assets/scss/doc-editor.scss
+++ b/app/addons/documents/assets/scss/doc-editor.scss
@@ -202,8 +202,13 @@
   max-width: 540px;
   text-align: left;
   overflow: hidden;
-  a:hover {
-    color: $cf-brand-hightlight-hover;
+  a {
+    background-color: $cf-navbar-bg;
+    color: $cf-white;
+
+    &:hover {
+      background-color: $cf-brand-hightlight-hover;
+    }
   }
 }
 

--- a/app/addons/documents/assets/scss/doc-editor.scss
+++ b/app/addons/documents/assets/scss/doc-editor.scss
@@ -203,9 +203,10 @@
   text-align: left;
   overflow: hidden;
   a {
-    background-color: $cf-navbar-bg;
-    color: $cf-white;
-
+    background-color: $cf-dropdown-item-bg;
+    color: $cf-dropdown-item-color;
+    margin-bottom: 2px;
+    
     &:hover {
       background-color: $cf-brand-hightlight-hover;
     }

--- a/app/addons/documents/doc-editor/components/AttachmentsPanelButton.js
+++ b/app/addons/documents/doc-editor/components/AttachmentsPanelButton.js
@@ -38,7 +38,7 @@ export default class AttachmentsPanelButton extends React.Component {
     return _.map(this.props.doc.get('_attachments'), (item, filename) => {
       const url = FauxtonAPI.urls('document', 'attachment', db, doc, encodeURIComponent(filename));
       return (
-        <Dropdown.Item key={filename} href={url} target="_blank" data-bypass="true">
+        <Dropdown.Item key={filename} href={url} target="_blank" data-bypass="true" className="jkf-test">
           <strong>{filename}</strong>
           <span className="attachment-delimiter">-</span>
           <span>{item.content_type}{item.content_type ? ', ' : ''}{Helpers.formatSize(item.length)}</span>


### PR DESCRIPTION
Fix dropdown of the View Attachments button 

Done in the style of the View edit dropdown: 
   
<img width="214" alt="image" src="https://user-images.githubusercontent.com/94444185/222727302-5b4477ea-6246-48d6-9080-ff29c6faed86.png">


### Screenshots
<img width="683" alt="Screenshot 2023-03-03 at 12 59 24" src="https://user-images.githubusercontent.com/94444185/222727217-6722bf46-8197-459a-af60-55e9ec32fa28.png">
