### PR TITLE
make attachments dropdown consistent with main sidebar

### DIFF
--- a/app/addons/documents/assets/scss/doc-editor.scss
+++ b/app/addons/documents/assets/scss/doc-editor.scss
@@ -202,6 +202,9 @@
   max-width: 540px;
   text-align: left;
   overflow: hidden;
+  padding-bottom:0;
+  border-radius:0;
+
   a {
     background-color: $cf-dropdown-item-bg;
     color: $cf-dropdown-item-color;
@@ -209,6 +212,10 @@
     
     &:hover {
       background-color: $cf-brand-hightlight-hover;
+    }
+
+    &:last-child {
+      margin-bottom:0;
     }
   }
 }


### PR DESCRIPTION
- make attachments dropdown consistent with main sidebar

### Screenshots
![Screenshot 2023-03-08 at 12 28 47](https://user-images.githubusercontent.com/94444185/223713545-954dab78-ded3-4f57-9bdf-8d23990ec567.png)

---

![Screenshot 2023-03-08 at 12 28 50](https://user-images.githubusercontent.com/94444185/223713551-380a4126-6ac0-4797-af46-49d50f424f8c.png)
