### PR TITLE
update cf-info colour

### DIFF
--- a/app/addons/documents/assets/scss/query-options.scss
+++ b/app/addons/documents/assets/scss/query-options.scss
@@ -25,7 +25,7 @@
   .fonticon-help-circled {
     margin-left: 3px;
     font-size: 17.5px;
-    color: $cf-secondary;
+    color: $cf-info;
     &:hover {
       color: $cf-brand-hightlight-hover;
     }

--- a/assets/scss/_variables.scss
+++ b/assets/scss/_variables.scss
@@ -55,7 +55,7 @@ $cf-primary: #208019 !default;
 $cf-secondary: #0076AD !default;
 $cf-danger: #E00025 !default;
 $cf-success: #448c11 !default;
-$cf-info: #329898 !default;
+$cf-info: #3CB4B4 !default;
 $cf-error: #d9534f !default;
 $cf-warning: #d9c74f !default;
 $cf-white: #ffffff !default;


### PR DESCRIPTION
- update `cf-info` colour.
   - Used in a couple of places, namely on the `options` dropdown for the "more info" icon, and as the left border on toasts.
   - The icon contrast ratio was previously `2.52:1`, and is now `5.04:1`. The left border on toasts hovers around `2:1`, but this is less important.

### Screenshots
![image](https://user-images.githubusercontent.com/94444185/226874121-3d60cf6f-1596-4c9a-96d4-b7375dc8b10a.png)

![image](https://user-images.githubusercontent.com/94444185/226874239-13299258-a4ee-4214-8a32-16f46fa5d727.png)


