### PR TITLE
fix replications bug

### DIFF
--- a/app/addons/replication/actions.js
+++ b/app/addons/replication/actions.js
@@ -51,7 +51,7 @@ export const getDatabasesList = () => dispatch => {
     });
 };
 
-export const replicate = (params, pageLimit) => dispatch => {
+export const replicate = (params, pageLimit = 100) => dispatch => {
   const replicationDoc = createReplicationDoc(params);
   const url = MainHelper.getServerUrl("/_replicator");
   const promise = post(url, replicationDoc);

--- a/app/addons/replication/route.js
+++ b/app/addons/replication/route.js
@@ -45,6 +45,7 @@ const ReplicationRouteObject = FauxtonAPI.RouteObject.extend({
     return <ReplicationController
       routeLocalSource={localSource}
       section={'new replication'}
+      pageLimit={100}
     />;
   },
 
@@ -52,6 +53,7 @@ const ReplicationRouteObject = FauxtonAPI.RouteObject.extend({
     return <ReplicationController
       replicationId={replicationId}
       section={'new replication'}
+      pageLimit={100}
     />;
   },
 


### PR DESCRIPTION
- Fix replications bug
   - When the user was returned to the replications table after creating a new replication, no results were shown. However, when the page was refreshed, results were shown. This was because no page limit value was specified, which resulted in the following request being made: `http://localhost:8000/_replicator/_all_docs?include_docs=true&limit=NaN`

