### PR TITLE
fix replications page layout issue

### DIFF
--- a/app/addons/replication/assets/scss/replication.scss
+++ b/app/addons/replication/assets/scss/replication.scss
@@ -45,6 +45,7 @@ div.replication__page {
 
 .replication__activity {
   padding: 1rem;
+  padding-bottom: 50px;
   width: 100%;
 }
 


### PR DESCRIPTION
fix replications page layout issue
   - Bottom-most row is only partially visible at some screen sizes, as the height of the footer (containing `Showing replications 1 - 10`, etc.) hasn't been considered. This was introduced during our switch to Bootstrap v5.

### Screenshots (both at maximum scroll)
**Currently**
![Screenshot 2023-03-27 at 12 33 28](https://user-images.githubusercontent.com/94444185/227931941-38e6c4b2-d287-4c8d-96ac-a2aff795679f.png)
**These changes**
![image](https://user-images.githubusercontent.com/94444185/227932237-c5a0c516-3841-47c7-b448-b77d5d60b8d9.png)

